### PR TITLE
Implement python `index` method on string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ interface String {
   capitalize(): string;
 
   /**
-   * Returns the position of the first occurrence of a substring in a given range of string.
+   * Returns the position of the first occurrence of a substring in a given range of string if found, else throws ValueError.
    * @param value The substring to search.
    * @param start The position to start searching. If omitted, search starts at the beginning.
    * @param end Search upto this position. If omitted, searches till the end of the string.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+/** @format */
+
+interface String {
+  /**
+   * Returns the string converted to lower-case.
+   */
+  casefold(): string;
+
+  /**
+   * Returns the capitalized string.
+   */
+  capitalize(): string;
+
+  /**
+   * Returns the position of the first occurrence of a substring in a given range of string.
+   * @param value The substring to search.
+   * @param start The position to start searching. If omitted, search starts at the beginning.
+   * @param end Search upto this position. If omitted, searches till the end of the string.
+   */
+  index(value: string, start?: number, end?: number): number | undefined;
+}

--- a/index.js
+++ b/index.js
@@ -8,4 +8,14 @@ String.prototype.casefold = function () {
   return this.toLowerCase();
 };
 
+String.prototype.index = function (value, start = 0, end = this.length) {
+  position = this.slice(0, end).indexOf(value, start);
+  if (position != -1) return position;
+  else {
+    err = new Error("substring not found");
+    err.name = "ValueError";
+    throw err;
+  }
+};
+
 module.exports = {};

--- a/test.js
+++ b/test.js
@@ -84,4 +84,7 @@ test("index method returns the first occurrence of the substring in the given ra
 
   stringToSearch = "word";
   expect(() => inputString.index(stringToSearch)).toThrow(expectedValueError);
+
+  stringToSearch = " world.";
+  expect(() => inputString.index(stringToSearch)).toThrow(expectedValueError);
 });

--- a/test.js
+++ b/test.js
@@ -6,16 +6,82 @@ test("capitalize method capitalizes the first letter of the string and convert o
   var inputString = "hello world";
   var expectedOutput = "Hello world";
   expect(inputString.capitalize()).toBe(expectedOutput);
+
   inputString = "hello World";
   expectedOutput = "Hello world";
   expect(inputString.capitalize()).toBe(expectedOutput);
 });
 
-test("casefold method convert every letter to lowercase", () => {
+test("casefold method converts every letter to lowercase", () => {
   var inputString = "Hello World";
   var expectedOutput = "hello world";
   expect(inputString.casefold()).toBe(expectedOutput);
+
   inputString = "HELLO WORLD";
   expectedOutput = "hello world";
   expect(inputString.casefold()).toBe(expectedOutput);
+});
+
+test.only("index method returns the first occurrence of the substring in the given range", () => {
+  var inputString = "Hello world";
+  var expectedValueError = "substring not found";
+
+  var stringToSearch = "";
+  var expectedOutput = 0;
+  expect(inputString.index(stringToSearch)).toBe(expectedOutput);
+
+  stringToSearch = "H";
+  expectedOutput = 0;
+  expect(inputString.index(stringToSearch)).toBe(expectedOutput);
+
+  stringToSearch = "h";
+  expect(() => inputString.index(stringToSearch)).toThrow(expectedValueError);
+
+  stringToSearch = "H";
+  expect(() => inputString.index(stringToSearch, 1)).toThrow(
+    expectedValueError
+  );
+
+  stringToSearch = "e";
+  expectedOutput = 1;
+  expect(inputString.index(stringToSearch, 1, 2)).toBe(expectedOutput);
+
+  stringToSearch = "e";
+  expect(() => inputString.index(stringToSearch, 0, 1)).toThrow(
+    expectedValueError
+  );
+
+  stringToSearch = "o";
+  expectedOutput = 7;
+  expect(inputString.index(stringToSearch, 5)).toBe(expectedOutput);
+
+  stringToSearch = "o";
+  expectedOutput = 7;
+  expect(() => inputString.index(stringToSearch, 5, 7)).toThrow(
+    expectedValueError
+  );
+
+  stringToSearch = "Hello";
+  expectedOutput = 0;
+  expect(inputString.index(stringToSearch)).toBe(expectedOutput);
+
+  stringToSearch = "ello";
+  expectedOutput = 1;
+  expect(inputString.index(stringToSearch)).toBe(expectedOutput);
+
+  stringToSearch = "world";
+  expectedOutput = 6;
+  expect(inputString.index(stringToSearch)).toBe(expectedOutput);
+
+  stringToSearch = " w";
+  expectedOutput = 5;
+  expect(inputString.index(stringToSearch)).toBe(expectedOutput);
+
+  stringToSearch = "H";
+  expect(() => inputString.index(stringToSearch, 0, 0)).toThrow(
+    expectedValueError
+  );
+
+  stringToSearch = "word";
+  expect(() => inputString.index(stringToSearch)).toThrow(expectedValueError);
 });

--- a/test.js
+++ b/test.js
@@ -22,7 +22,7 @@ test("casefold method converts every letter to lowercase", () => {
   expect(inputString.casefold()).toBe(expectedOutput);
 });
 
-test.only("index method returns the first occurrence of the substring in the given range", () => {
+test("index method returns the first occurrence of the substring in the given range", () => {
   var inputString = "Hello world";
   var expectedValueError = "substring not found";
 


### PR DESCRIPTION
Fixes #4.

This PR does the following:
- Add python-like `index` method on string.
- Introduces doc-string to explain functions.
- **Add function definitions to show intellisense quick-info.** 