### PR TITLE
Add endswith function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,4 +26,13 @@ interface String {
    * @param end Search upto this position. If omitted, searches till the end of the string.
    */
   count(sub: string, start?: number, end?: number): number;
+
+  /**
+ * Returns true if the given string ends with the specified suffix within a specified range, else false.
+ * @param suffix The suffix to check.
+ * @param start The position to start checking. If omitted, check starts at the beginning.
+ * @param end Check up to this position. If omitted, checks until the end of the string.
+ */
+  endswith(suffix: string, start?: number, end?: number): boolean | undefined;
+
 }

--- a/index.js
+++ b/index.js
@@ -35,6 +35,15 @@ String.prototype.endswith = function (suffix, start = 0, end = this.length) {
   if (typeof suffix !== 'string') {
     throw new TypeError("'suffix' must be a string");
   }
+  if (end > this.length) {
+    end = this.length;
+  }
+  if (start < 0) {
+    start = 0;
+  }
+  if (end - start < suffix.length) {
+    return false;
+  }
   const substring = this.slice(start, end);
   return substring.endsWith(suffix);
 };

--- a/index.js
+++ b/index.js
@@ -33,23 +33,10 @@ String.prototype.count = function (sub, start = 0, end = this.length) {
 
 String.prototype.endswith = function (suffix, start = 0, end = this.length) {
   if (typeof suffix !== 'string') {
-    throw new Error("TypeError: 'suffix' must be a string");
+    throw new TypeError("'suffix' must be a string");
   }
-
-  if (end > this.length) {
-    end = this.length;
-  }
-
-  if (start < 0) {
-    start = 0;
-  }
-
-  if (end - start < suffix.length) {
-    return false;
-  }
-
   const substring = this.slice(start, end);
-  return substring.lastIndexOf(suffix) === substring.length - suffix.length;
+  return substring.endsWith(suffix);
 };
 
 module.exports = {};

--- a/index.js
+++ b/index.js
@@ -31,4 +31,25 @@ String.prototype.count = function (sub, start = 0, end = this.length) {
   return count;
 };
 
+String.prototype.endswith = function (suffix, start = 0, end = this.length) {
+  if (typeof suffix !== 'string') {
+    throw new Error("TypeError: 'suffix' must be a string");
+  }
+
+  if (end > this.length) {
+    end = this.length;
+  }
+
+  if (start < 0) {
+    start = 0;
+  }
+
+  if (end - start < suffix.length) {
+    return false;
+  }
+
+  const substring = this.slice(start, end);
+  return substring.lastIndexOf(suffix) === substring.length - suffix.length;
+};
+
 module.exports = {};

--- a/test.js
+++ b/test.js
@@ -163,6 +163,11 @@ test("endswith method determines whether the string ends with the specified suff
   expect(inputString.endswith(suffix)).toBe(expectedOutput);
 
   inputString = "Hello, World!";
+  suffix = "!";
+  expectedOutput = false;
+  expect(inputString.endswith(suffix, 10, 1)).toBe(expectedOutput);
+
+  inputString = "Hello, World!";
   suffix = "WORLD!";
   expectedOutput = false;
   expect(inputString.endswith(suffix)).toBe(expectedOutput);

--- a/test.js
+++ b/test.js
@@ -203,7 +203,7 @@ test("endswith method determines whether the string ends with the specified suff
   expect(inputString.endswith(suffix)).toBe(expectedOutput);
 
   inputString = "Hello, World!";
-  var expectedTypeError = "TypeError: 'suffix' must be a string";
+  var expectedTypeError = "'suffix' must be a string";
   suffix = 5;
   expect(() => inputString.endswith(suffix)).toThrow(expectedTypeError);
 

--- a/test.js
+++ b/test.js
@@ -145,3 +145,61 @@ test("count method returns the count the occurrences of a specified substring or
   expectedOutput = 0;
   expect(inputString.count(stringToSearch, 100, 7)).toBe(expectedOutput);
 });
+
+test("endswith method determines whether the string ends with the specified suffix", () => {
+  var inputString = "Hello, World!";
+  var suffix = "";
+  var expectedOutput = true;
+  expect(inputString.endswith(suffix)).toBe(expectedOutput);
+
+  inputString = "Hello, World!";
+  suffix = "World!";
+  expectedOutput = true;
+  expect(inputString.endswith(suffix)).toBe(expectedOutput);
+
+  inputString = "Hello, World!";
+  suffix = "Hello";
+  expectedOutput = false;
+  expect(inputString.endswith(suffix)).toBe(expectedOutput);
+
+  inputString = "Hello, World!";
+  suffix = "WORLD!";
+  expectedOutput = false;
+  expect(inputString.endswith(suffix)).toBe(expectedOutput);
+
+  inputString = "Hello, World!";
+  suffix = "o";
+  expectedOutput = true;
+  expect(inputString.endswith(suffix, -1, 5)).toBe(expectedOutput);
+
+  inputString = "Hello, World!";
+  suffix = "!";
+  expectedOutput = true;
+  expect(inputString.endswith(suffix, 5, 100)).toBe(expectedOutput);
+
+  inputString = "";
+  suffix = "";
+  expectedOutput = true;
+  expect(inputString.endswith(suffix)).toBe(expectedOutput);
+
+  inputString = "Hello, World!";
+  suffix = "Hello, World!";
+  expectedOutput = true;
+  expect(inputString.endswith(suffix)).toBe(expectedOutput);
+
+  inputString = "Hello, World!";
+  suffix = "!";
+  expectedOutput = true;
+  expect(inputString.endswith(suffix)).toBe(expectedOutput);
+
+  inputString = "Hello, World!";
+  suffix = "Hello, World! ";
+  expectedOutput = false;
+  expect(inputString.endswith(suffix)).toBe(expectedOutput);
+
+  inputString = "Hello, World!";
+  var expectedTypeError = "TypeError: 'suffix' must be a string";
+  suffix = 5;
+  expect(() => inputString.endswith(suffix)).toThrow(expectedTypeError);
+
+});


### PR DESCRIPTION
Method: [`endsWith()`](https://docs.python.org/3/library/stdtypes.html#str.endswith)

Description:
This method determines whether the given string ends with the specified suffix within a specified range. It provides functionality similar to the `endswith()` method available in Python for string objects.

Parameters:

- `suffix` (string): The suffix to check for at the end of the string.
- `start` (optional, number): The position from which to start checking. If omitted, the check starts from the beginning of the string.
- `end` (optional, number): The position up to which the check is performed. If omitted, the check continues until the end of the string.

Returns:
- `result` (boolean): true if the string ends with the specified suffix within the given range, otherwise false.