### PR TITLE
Add split function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,4 +35,11 @@ interface String {
  */
   endswith(suffix: string, start?: number, end?: number): boolean | undefined;
 
+  /**
+ * Returns an array of substrings obtained after splitting the given string using a specified separator and maximum number of splits.
+ * @param separator The string used to determine where to split the string.
+ * @param maxsplit The maximum number of splits. If omitted or negative, the string is split as many times as possible.
+ */
+  split(separator?: string, maxsplit?: number): string[];
+
 }

--- a/index.js
+++ b/index.js
@@ -48,4 +48,26 @@ String.prototype.endswith = function (suffix, start = 0, end = this.length) {
   return substring.endsWith(suffix);
 };
 
+String.prototype.split = function (separator = " ", maxsplit = -1) {
+  if (typeof separator !== 'string') {
+    throw new TypeError("'separator' must be a string");
+  }
+  if (typeof maxsplit !== 'number') {
+    throw new TypeError("'maxsplit' must be a number");
+  }
+  if (separator === "") {
+    throw new Error("ValueError: 'separator' cannot be empty");
+  }
+  if (maxsplit === 0) {
+    return [this.toString()];
+  }
+  const result = maxsplit > 0 ? this.split(separator, maxsplit - 1) : this.split(separator);
+  return result.map((substring, index) => {
+    if (index >= result.length - 1) {
+      return substring;
+    }
+    return maxsplit === -1 ? substring : substring + separator;
+  });
+};
+
 module.exports = {};

--- a/test.js
+++ b/test.js
@@ -208,3 +208,65 @@ test("endswith method determines whether the string ends with the specified suff
   expect(() => inputString.endswith(suffix)).toThrow(expectedTypeError);
 
 });
+
+test("split method splits the string into an array of substrings", () => {
+  var inputString = "Hello, World!";
+  var separator = ",";
+  var expectedOutput = ["Hello", " World!"];
+  expect(inputString.split(separator)).toEqual(expectedOutput);
+
+  separator = " ";
+  expectedOutput = ["Hello,", "World!"];
+  expect(inputString.split(separator)).toEqual(expectedOutput);
+
+  separator = "o";
+  expectedOutput = ["Hell", ", W", "rld!"];
+  expect(inputString.split(separator)).toEqual(expectedOutput);
+
+  separator = "!";
+  expectedOutput = ["Hello, World"];
+  expect(inputString.split(separator)).toEqual(expectedOutput);
+
+  separator = " ";
+  var maxsplit = 1;
+  expectedOutput = ["Hello,", "World!"];
+  expect(inputString.split(separator, maxsplit)).toEqual(expectedOutput);
+
+  separator = " ";
+  maxsplit = 2;
+  expectedOutput = ["Hello,", "World!"];
+  expect(inputString.split(separator, maxsplit)).toEqual(expectedOutput);
+
+  separator = " ";
+  maxsplit = 0;
+  expectedOutput = ["Hello, World!"];
+  expect(inputString.split(separator, maxsplit)).toEqual(expectedOutput);
+
+  separator = " ";
+  maxsplit = -1;
+  expectedOutput = ["Hello,", "World!"];
+  expect(inputString.split(separator, maxsplit)).toEqual(expectedOutput);
+
+  separator = " ";
+  maxsplit = 2;
+  expectedOutput = ["Hello,", "World!"];
+  expect(inputString.split(separator, maxsplit)).toEqual(expectedOutput);
+
+  separator = " ";
+  maxsplit = 100;
+  expectedOutput = ["Hello,", "World!"];
+  expect(inputString.split(separator, maxsplit)).toEqual(expectedOutput);
+
+  var expectedTypeError = "'separator' must be a string";
+  separator = 123; // Not a string
+  expect(() => inputString.split(separator)).toThrow(expectedTypeError);
+
+  expectedTypeError = "'maxsplit' must be a number";
+  separator = " ";
+  maxsplit = "abc"; // Not a number
+  expect(() => inputString.split(separator, maxsplit)).toThrow(expectedTypeError);
+
+  var expectedValueError = "ValueError: 'separator' cannot be empty";
+  separator = "";
+  expect(() => inputString.split(separator)).toThrow(expectedValueError);
+});


### PR DESCRIPTION
Method: [`split()`](https://docs.python.org/3/library/stdtypes.html#str.split)

Description:
This method on a string splits the string into an array of substrings based on a specified separator. It functions similarly to the `split()` method available in Python for string objects.

Parameters:
- `separator` (string, optional): The separator used to split the string. If omitted, the default separator is a space character.
- `maxsplit` (number, optional): The maximum number of splits to perform. If omitted, all possible splits are performed.

Returns:
- `result` (array of strings): An array containing the substrings obtained by splitting the original string using the specified separator.